### PR TITLE
Extend with extra_params fix (rates/tracking)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -544,7 +544,7 @@ function UPS(args) {
     request['Shipment'] = buildShipment(data, options);
 
     if(options && options.extra_params && typeof options.extra_params === 'object') {
-      request = extend(request, options.extra_params);
+      request = extend(true, request, options.extra_params);
     }
 
     root.ele(request);
@@ -602,7 +602,7 @@ function UPS(args) {
 
     request['TrackingNumber'] = tracking_number;
     if(options && options.extra_params && typeof options.extra_params === 'object') {
-      request = extend(request, options.extra_params);
+      request = extend(true, request, options.extra_params);
     }
 
     root.ele(request);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shipping-ups",
-  "version": "0.4.30",
+  "version": "0.4.31",
   "description": "UPS API bindings for Node.JS",
   "keywords": [
     "shipping",


### PR DESCRIPTION
When calling rates and tracking with `options.extra_params`, the call to `extend` was overwriting the normal request parameters. This is the same issue as the one fixed by [this commit](https://github.com/typefoo/node-shipping-ups/commit/ccc0c9e957e82c75c5bcb2f5f9157ea67dfd55c6), I believe.