### PR TITLE
Add option for NegotiatedRatesIndicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,10 @@ Get a list of shipping rates
       }
     ]
   }
+
+  options = {
+    negotiated_rates: true // Optional, but if truthy then the NegotiatedRatesIndicator will always be placed (even without state/province code). Useful for countries without provinces.
+  }
 ```
 
 ### confirm(data, [options,] callback)
@@ -379,6 +383,10 @@ Pick a shipping rate
         ]
       }
     ]
+  }
+
+  options = {
+    negotiated_rates: true // See rates options.
   }
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -336,10 +336,8 @@ function UPS(args) {
       }
     }
 
-    if(data.ship_to.address.state_code) {
-      shipment.RateInformation = {
-        NegotiatedRatesIndicator: 'true'
-      };
+    if(data.ship_to.address.state_code || options.negotiated_rates) {
+      shipment.RateInformation = ["NegotiatedRatesIndicator"];
     }
 
     shipment['#list'] = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shipping-ups",
-  "version": "0.4.31",
+  "version": "0.4.32",
   "description": "UPS API bindings for Node.JS",
   "keywords": [
     "shipping",


### PR DESCRIPTION
The UPS API manual says that one has to add a state/province code to get negotiated rates correctly, but actually for countries that don't have provinces (e.g., France) the API requires that we *don't* put any province code.

Also, it doesn't really make any difference but the UPS manual says NegotiatedRatesIndicator is supposed to be a self-closing element like `<NegotiatedRatesIndicator />`, so I changed that too.