### PR TITLE
Add ZPL support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -479,7 +479,19 @@ function UPS(args) {
         }
       };
       break;
-    // Also supported by the UPS API but not supported here: ZPL, SPL, STARPL
+    case 'ZPL':
+      label = {
+        'LabelPrintMethod': {
+          'Code': 'ZPL',
+          'Description': 'zpl2 file'
+        },
+        'LabelStockSize': {
+          'Height': '4',
+          'Width': '6',
+        }
+      };
+      break;
+    // Also supported by the UPS API but not supported here: SPL, STARPL
     default:
       throw new Error("unsupported label type " + label_type);
     }


### PR DESCRIPTION
Fortunately, the options required for the ZPL format are the same as those required for the EPL format. I can see the potential need to add a mechanism for dynamically setting the `LabelStockSize`, but this code as it stands will allow users to request valid ZPL labels.