### PR TITLE
support reference_number.bar_code_indicator on confirm reqs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -421,6 +421,10 @@ function UPS(args) {
           'Code': data.packages[i].reference_number.code,
           'Value': data.packages[i].reference_number.value
         };
+
+        if ( typeof data.packages[i].reference_number.bar_code_indicator !== 'undefined' ) {
+          p['Package']['ReferenceNumber']['BarCodeIndicator'] = data.packages[i].reference_number.bar_code_indicator;
+        }
       } else if(data.packages[i].reference_number && data.packages[i].reference_number instanceof Array) {
         // Array of ReferenceNumbers
         p['Package']['#list'] = [];


### PR DESCRIPTION
This patch allows `ShipConfirmRequest`s to optionally support barcode indicators for supplied reference numbers